### PR TITLE
change memory from 512->256

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -14,7 +14,7 @@ declared-services:
     plan: standard
 applications:
 - path: .
-  memory: 512M
+  memory: 256M
   instances: 1
   name: watson-banking-chatbot
   disk_quota: 256M


### PR DESCRIPTION
In anticipation of Bluemix's freemium changes, we should change the app memory from 512 to 256 (since 256 is in the free tier)