### PR TITLE
Kubernetes Instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node server.js",
+    "debug": "node --debug server.js",
     "test": "npm run unit && npm run eslint && npm run jshint",
     "jshint": "jshint public",
     "eslint": "eslint *.js lib test",


### PR DESCRIPTION
I added instructions in `README.md` to quickly target the Kubernetes environment on Bluemix using the IBM Cloud Developer Tools CLI, and one minor modification to `package.json` so that it is compatible with `bx dev debug` commands from the CLI.  

This uses the same steps as running locally, and uses `bx dev enable` to generate Kubernetes assets, with `bx dev deploy` to handle compilation of the Docker image, push to IBM Container Registry, and the subsequent push to Kubernetes using the generated helm chart.

This does not cover Watson service bindings to Kubernetes clusters, as that requires more changes to the application code, and is not fully supported by the Cloud Developer Tools CLI *yet*.