### PR TITLE
accounType is still referenced

### DIFF
--- a/public/js/common.js
+++ b/public/js/common.js
@@ -82,8 +82,12 @@ var Common = (function() {
 }());
 
 
+// When this old typo name got fixed it broke references in some dialog nodes.
+function accounType (response){
+  accountType(response);
+}
 
- function accountType (response){
+function accountType (response){
 var res=response;
 
    var context;


### PR DESCRIPTION
Fixes #141

A typo in a function name was fixed, but it is still referenced in some dialog nodes
that return html buttons and function calls.

Make the old name and new name both work.  Sigh.